### PR TITLE
Update eFatura runtime to 46

### DIFF
--- a/org.kekikakademi.eFatura.yml
+++ b/org.kekikakademi.eFatura.yml
@@ -2,7 +2,7 @@
 
 app-id: org.kekikakademi.eFatura
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: eFaturaGUI
 


### PR DESCRIPTION
- Update eFatura runtime to 46 since runtime version 44 has reached end-of-life.